### PR TITLE
[Resolves #36] Fix Getting Started section to use class

### DIFF
--- a/docs/_documentation/getting-started.md
+++ b/docs/_documentation/getting-started.md
@@ -19,13 +19,13 @@ Setup your collection or blog template, for example:
 {% highlight liquid %}
 {% raw %}
 {% paginate collection.products by 3 %}
-    <div id="AjaxinateLoop" >
+    <div class="AjaxinateLoop" >
       {% for product in collection.products %}
         {% include 'product-grid-item' %}
       {% endfor %}
     </div>
 
-    <div id="AjaxinatePagination">
+    <div class="AjaxinatePagination">
       {% if paginate.next %}
         <a href="{{ paginate.next.url }}">Loading More</a>
       {% endif %}


### PR DESCRIPTION
Example in Getting Started section demonstrating the default example using ID instead of classes, which differs from the default in source code