### PR TITLE
[Resolves #36] Update default selectors to using IDs

### DIFF
--- a/docs/_documentation/settings.md
+++ b/docs/_documentation/settings.md
@@ -17,8 +17,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
 Option      | Default                | Type     | Description
 ------------|------------------------|----------|-------------
-pagination  | `.AjaxinatePagination` | String   | A selector to identify the pagination container.
-container   | `.AjaxinateLoop`       | String   | A selector to identify the grid that you want to duplicate.
+pagination  | `#AjaxinatePagination` | String   | A selector to identify the pagination container.
+container   | `#AjaxinateLoop`       | String   | A selector to identify the grid that you want to duplicate.
 method      | `scroll`               | String   | Can be changed to click to that users must click to load more.
 offset      | `0`                    | Integer  | Decrease the distance required to scroll before sending a request.
 loadingText | `Loading`              | String   | Change the text of the pagination link during a request.

--- a/src/ajaxinate.js
+++ b/src/ajaxinate.js
@@ -25,9 +25,9 @@ const Ajaxinate = function ajaxinateConstructor(config) {
     callback: null, function to callback after a new page is loaded
   */
   const defaultSettings = {
-    pagination: '.AjaxinatePagination',
+    pagination: '#AjaxinatePagination',
     method: 'scroll',
-    container: '.AjaxinateLoop',
+    container: '#AjaxinateLoop',
     offset: 0,
     loadingText: 'Loading',
     callback: null,


### PR DESCRIPTION
Instead of updating the docs solely, opting to use IDs is a better alternative. @Cam Since there will be breaking changes, I think this should go as a major release?