### PR TITLE
Added Page load and Scroll end Events

### DIFF
--- a/src/ajaxinate.js
+++ b/src/ajaxinate.js
@@ -128,12 +128,19 @@ Ajaxinate.prototype.loadMore = function loadMore() {
 
     if (typeof newPagination === 'undefined') {
       this.removePaginationElement();
+      document.dispatchEvent(new CustomEvent('ajaxinate.scroll:end'));
     } else {
       this.paginationElement.innerHTML = newPagination.innerHTML;
 
       if (this.settings.callback && typeof this.settings.callback === 'function') {
         this.settings.callback(this.request.responseXML);
       }
+
+      document.dispatchEvent(new CustomEvent('ajaxinate.page:load', { 
+        detail: {
+          content: newContainer
+        }
+      }));
 
       this.initialize();
     }


### PR DESCRIPTION
Sorry if this is not a great PR. It is the first I've done for public projects.

I added 2 events that extend the flexibility of the library:
- ajaxinate.page:load : This event fires when a new page is loaded. 
- ajaxinate.scroll:end : This event fires when there is no more pages left to load.

I've had to add those in my code since the callback forces me to handle everything in 1 place instead of being able to handle different things in different places of the code.

Hope it helps the project.

Best,
@adearriba